### PR TITLE
Add basic report comparison tool

### DIFF
--- a/docs/report-viewer-design.md
+++ b/docs/report-viewer-design.md
@@ -1,0 +1,8 @@
+# Report Viewer Design
+
+This document describes the design process of the viewer tool for the reports.
+
+## Use Cases
+
+1. A user wants to view which are the most energy heavy test methods.
+2. A user wants to compare the energy consumtion across two versions (reports) in order to validate their improvements.

--- a/docs/report-viewer-design.md
+++ b/docs/report-viewer-design.md
@@ -1,8 +1,0 @@
-# Report Viewer Design
-
-This document describes the design process of the viewer tool for the reports.
-
-## Use Cases
-
-1. A user wants to view which are the most energy heavy test methods.
-2. A user wants to compare the energy consumtion across two versions (reports) in order to validate their improvements.

--- a/reporterdashboard/dashboard.py
+++ b/reporterdashboard/dashboard.py
@@ -1,8 +1,13 @@
 import json
+import argparse
 
 
 def get_matching_test_cases(test_cases_1, test_cases_2):
-    # copy the lists over to a new object
+    """Returns test cases that are both in test_cases_1 and test_cases_2.
+
+    Test cases are ordered by their name.
+    """
+    # create sorted copies
     sorted_1 = sorted(test_cases_1, key=lambda d: d["name"])
     sorted_2 = sorted(test_cases_2, key=lambda d: d["name"])
     overlapping_test_cases = []
@@ -12,6 +17,11 @@ def get_matching_test_cases(test_cases_1, test_cases_2):
             break
 
         if sorted_1[0]["name"] == sorted_2[0]["name"]:
+            # only include passing tests
+            if sorted_1[0]["result"] != "pass" or sorted_2[0]["result"] != "pass":
+                sorted_1.pop(0)
+                sorted_2.pop(0)
+                continue
             overlapping_test_cases.append((sorted_1.pop(0), sorted_2.pop(0)))
         elif sorted_1[0]["name"] < sorted_2[0]["name"]:
             sorted_1.pop(0)
@@ -20,21 +30,83 @@ def get_matching_test_cases(test_cases_1, test_cases_2):
     return overlapping_test_cases
 
 
-if __name__ == "__main__":
-    # read the two file paths from arguments
-    file1_path = "example-reports/report1.json"
-    file2_path = "example-reports/report2.json"
-    with open(file1_path) as f:
-        file1_data = json.load(f)
-    with open(file2_path) as f:
-        file2_data = json.load(f)
+def print_energy_differences(data):
+    """Prints the energy difference for every test combination tuple in data.
 
-    # TODO make sure both tests were run on the same hardware
+    Keyword arguments:
+    data -- list of tuples each containing two test measurements
+    """
+    for testcombi in data:
+        # calculate average information
+        if len(testcombi) != 2:
+            raise TypeError(
+                f"Data tuple should have two data objects (actual is {len(testcombi)})."
+            )
+        N_0 = testcombi[0]["N"]
+        e_0 = 0
+        p_0 = 0
+        t_0 = 0
+        for i in range(0, N_0):
+            e_0 += testcombi[0]["energy"][i]
+            p_0 += testcombi[0]["power"][i]
+            t_0 += testcombi[0]["execution_time"][i]
+        e_0 /= N_0
+        p_0 /= N_0
+        t_0 /= N_0
+
+        N_1 = testcombi[1]["N"]
+        e_1 = 0
+        p_1 = 0
+        t_1 = 0
+        for i in range(0, N_1):
+            e_1 += testcombi[1]["energy"][i]
+            p_1 += testcombi[1]["power"][i]
+            t_1 += testcombi[1]["execution_time"][i]
+        e_1 /= N_1
+        p_1 /= N_1
+        t_1 /= N_1
+
+        print(
+            f"Test: {testcombi[0]['name']}\n"
+            f"  Run 1:\n"
+            f"    Time: {t_0} [ms]\n"
+            f"    Energy: {e_0} [J]\n"
+            f"    Power: {p_0} [W]\n"
+            f"  Run 2:\n"
+            f"    Time: {t_1} [ms]\n"
+            f"    Energy: {e_1} [J]\n"
+            f"    Power: {p_1} [W]\n"
+            f"  Difference (run 2 - run 1):\n"
+            f"    Time: {t_1 - t_0} [ms]\n"
+            f"    Energy: {e_1 - e_0} [J]\n"
+            f"    Power: {p_1 - p_0} [W]\n"
+            f"\n"
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ReporterDashboard",
+        description="Displays energy differences between two reports.",
+    )
+    parser.add_argument("report1", help="full path to the first report")
+    parser.add_argument("report2", help="full path to the second report")
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = _parser()
+    args = parser.parse_args()
+
+    with open(args.report1) as f:
+        file1_data = json.load(f)
+    with open(args.report2) as f:
+        file2_data = json.load(f)
 
     file1_data = file1_data["results"]["cases"]
     file2_data = file2_data["results"]["cases"]
 
     matching_test_cases = get_matching_test_cases(file1_data, file2_data)
 
-    print(matching_test_cases)
-
+    print_energy_differences(matching_test_cases)

--- a/reporterdashboard/dashboard.py
+++ b/reporterdashboard/dashboard.py
@@ -1,0 +1,40 @@
+import json
+
+
+def get_matching_test_cases(test_cases_1, test_cases_2):
+    # copy the lists over to a new object
+    sorted_1 = sorted(test_cases_1, key=lambda d: d["name"])
+    sorted_2 = sorted(test_cases_2, key=lambda d: d["name"])
+    overlapping_test_cases = []
+
+    while True:
+        if len(sorted_1) == 0 or len(sorted_2) == 0:
+            break
+
+        if sorted_1[0]["name"] == sorted_2[0]["name"]:
+            overlapping_test_cases.append((sorted_1.pop(0), sorted_2.pop(0)))
+        elif sorted_1[0]["name"] < sorted_2[0]["name"]:
+            sorted_1.pop(0)
+        else:
+            sorted_2.pop(0)
+    return overlapping_test_cases
+
+
+if __name__ == "__main__":
+    # read the two file paths from arguments
+    file1_path = "example-reports/report1.json"
+    file2_path = "example-reports/report2.json"
+    with open(file1_path) as f:
+        file1_data = json.load(f)
+    with open(file2_path) as f:
+        file2_data = json.load(f)
+
+    # TODO make sure both tests were run on the same hardware
+
+    file1_data = file1_data["results"]["cases"]
+    file2_data = file2_data["results"]["cases"]
+
+    matching_test_cases = get_matching_test_cases(file1_data, file2_data)
+
+    print(matching_test_cases)
+

--- a/reporterdashboard/example-reports/r1.json
+++ b/reporterdashboard/example-reports/r1.json
@@ -1,0 +1,78 @@
+{
+    "results": {
+        "name": "Test Report 1",
+        "version": 0.1,
+        "cases": [
+            {
+                "name": "test_a",
+                "result": "pass",
+                "N": 1,
+                "execution_time": [
+                    1000
+                ],
+                "energy": [
+                    200
+                ],
+                "power": [
+                    200
+                ] 
+            },
+            {
+                "name": "test_b",
+                "result": "pass",
+                "N": 1,
+                "execution_time": [
+                    1000
+                ],
+                "energy": [
+                    200
+                ],
+                "power": [
+                    200
+                ] 
+            },
+            {
+                "name": "test_c",
+                "result": "pass",
+                "N": 1,
+                "execution_time": [
+                    1000
+                ],
+                "energy": [
+                    200
+                ],
+                "power": [
+                    200
+                ] 
+            },
+            {
+                "name": "test_d",
+                "result": "pass",
+                "N": 1,
+                "execution_time": [
+                    1000
+                ],
+                "energy": [
+                    200
+                ],
+                "power": [
+                    200
+                ] 
+            },
+            {
+                "name": "test_e",
+                "result": "pass",
+                "N": 1,
+                "execution_time": [
+                    1000
+                ],
+                "energy": [
+                    200
+                ],
+                "power": [
+                    200
+                ] 
+            }
+        ]
+    }
+}

--- a/reporterdashboard/example-reports/r2.json
+++ b/reporterdashboard/example-reports/r2.json
@@ -1,0 +1,64 @@
+{
+    "results": {
+        "name": "Test Report 2",
+        "version": 0.1,
+        "cases": [
+            {
+                "name": "test_e",
+                "result": "pass",
+                "N": 1,
+                "execution_time": [
+                    1000
+                ],
+                "energy": [
+                    200
+                ],
+                "power": [
+                    200
+                ] 
+            },
+            {
+                "name": "test_a",
+                "result": "pass",
+                "N": 1,
+                "execution_time": [
+                    1000
+                ],
+                "energy": [
+                    200
+                ],
+                "power": [
+                    200
+                ] 
+            },
+            {
+                "name": "test_c",
+                "result": "pass",
+                "N": 1,
+                "execution_time": [
+                    1000
+                ],
+                "energy": [
+                    200
+                ],
+                "power": [
+                    200
+                ] 
+            },
+            {
+                "name": "test_nope",
+                "result": "pass",
+                "N": 1,
+                "execution_time": [
+                    1000
+                ],
+                "energy": [
+                    200
+                ],
+                "power": [
+                    200
+                ] 
+            }
+        ]
+    }
+}

--- a/reporterdashboard/example-reports/report1.json
+++ b/reporterdashboard/example-reports/report1.json
@@ -1,0 +1,71 @@
+{
+	"results": {
+		"name": "Hello World!",
+		"description": "This is some extra description that can be displayed for convenience.\nDo whatever you need.",
+		"version": 1,
+		"software_version": "v1.2BETA",
+		"commit": "755f02b971d59acd85d3aa727baa0e822efcd73f",
+		"date": "2024-03-11T16:50:00",
+		"model": "https://github.com/green-coding-solutions/spec-power-model",
+		"hardware": {
+			"PC_name": "Aron's Laptop",
+			"CPU_name": "AMD® Ryzen 9 7940hs w/ radeon 780m graphics",
+			"CPU_temp": 40.3,
+			"CPU_freq": 2000
+		},
+		"cases": [
+			{
+				"name": "test_user_supplies_incomplete_information",
+				"result": "fail",
+				"reason": "AssertionError: Invalid Operation",
+				"N": 3,
+				"execution_time": [
+					1000,
+					1000,
+					1000
+				],
+				"energy": [
+					0,
+					0,
+					0
+				],
+				"power": [
+					0,
+					0,
+					0
+				],
+				"_my_custom_field": "This is so epic!",
+				"_test_params": {
+					"param1": "<value1>",
+					"param2": "<value2>"
+				}
+			},
+			{
+				"name": "test_user_supplies_complete_information",
+				"result": "pass",
+				"reason": "",
+				"N": 3,
+				"execution_time": [
+					50000,
+					50200,
+					50100
+				],
+				"energy": [
+					16.3,
+					16.2,
+					16.5
+				],
+				"power": [
+					0.326,
+					0.32270916334661354,
+					0.32934131736526945
+				],
+				"_my_custom_field": "This is so epic!",
+				"_test_params": {
+					"param1": "<value1>",
+					"param2": "<value2>"
+				}
+			}
+		]
+	}
+}

--- a/reporterdashboard/example-reports/report2.json
+++ b/reporterdashboard/example-reports/report2.json
@@ -1,0 +1,71 @@
+{
+	"results": {
+		"name": "Hello World!",
+		"description": "This is some extra description that can be displayed for convenience.\nDo whatever you need.",
+		"version": 1,
+		"software_version": "v1.2BETA",
+		"commit": "755f02b971d59acd85d3aa727baa0e822efcd73f",
+		"date": "2024-03-11T17:00:00",
+		"model": "https://github.com/green-coding-solutions/spec-power-model",
+		"hardware": {
+			"PC_name": "Aron's Laptop",
+			"CPU_name": "AMD® Ryzen 9 7940hs w/ radeon 780m graphics",
+			"CPU_temp": 40.3,
+			"CPU_freq": 2000
+		},
+		"cases": [
+			{
+				"name": "test_user_supplies_incomplete_information",
+				"result": "fail",
+				"reason": "AssertionError: Invalid Operation",
+				"N": 3,
+				"execution_time": [
+					1000,
+					1000,
+					1000
+				],
+				"energy": [
+					0,
+					0,
+					0
+				],
+				"power": [
+					0,
+					0,
+					0
+				],
+				"_my_custom_field": "This is so epic!",
+				"_test_params": {
+					"param1": "<value1>",
+					"param2": "<value2>"
+				}
+			},
+			{
+				"name": "test_user_supplies_complete_information",
+				"result": "pass",
+				"reason": "",
+				"N": 3,
+				"execution_time": [
+					50000,
+					50200,
+					50100
+				],
+				"energy": [
+					14.3,
+					14.2,
+					14.5
+				],
+				"power": [
+					0.28600000000000003,
+					0.2828685258964143,
+					0.2894211576846307
+				],
+				"_my_custom_field": "This is so epic!",
+				"_test_params": {
+					"param1": "<value1>",
+					"param2": "<value2>"
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
Adds a minimal tool which shows the user a diff of two input reports. Tests are ordered by their name and only passing tests are included.

An output can look like following:

```
aron@laptop: ~/energy-consumption-reporter/reporterdashboard$ python dashboard.py example-reports/report1.json example-reports/report2.json 
Test: test_user_supplies_complete_information
  Run 1:
    Time: 50100.0 [ms]
    Energy: 16.333333333333332 [J]
    Power: 0.326016826903961 [W]
  Run 2:
    Time: 50100.0 [ms]
    Energy: 14.333333333333334 [J]
    Power: 0.2860965611936817 [W]
  Difference (run 2 - run 1):
    Time: 0.0 [ms]
    Energy: -1.9999999999999982 [J]
    Power: -0.03992026571027929 [W]
```