### PR TITLE
Add dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ This project uses Python 3.10.
 
 <!-- TODO add project description -->
 
+## Dependencies
+
+### Windows
+
+### Linux
+
+- [lm-sensors](https://github.com/lm-sensors/lm-sensors) - the command `sensors -j` is used for extracting information about the CPU temperature.
+
 ## Usage
 
 There are two main ways to use this project:


### PR DESCRIPTION
Add dependency for `lm-sensor` to README for linux.

There are probably some other dependencies that are not yet listen, so I welcome you to add extra dependencies to the README. For this reason the PR is in draft mode.